### PR TITLE
Add clickable links

### DIFF
--- a/cmd/cireport/main.go
+++ b/cmd/cireport/main.go
@@ -51,11 +51,11 @@ func main() {
 			finishedAt.Sub(startedAt).String(), // Duration
 			result,                             // Result
 			"",                                 // Fixed failure?
-			"",                                 // Logs
-			"",                                 // Machines.json
-			"",                                 // Nodes
-			"cireport",                         // CI Cop
-			rootCause,                          // Root Cause
+			fmt.Sprintf(`=HYPERLINK("%s")`, j.BuildLogURL()), // Logs
+			fmt.Sprintf(`=HYPERLINK("%s")`, j.MachinesURL()), // Machines.json
+			fmt.Sprintf(`=HYPERLINK("%s")`, j.NodesURL()),    // Nodes
+			"cireport", // CI Cop
+			rootCause,  // Root Cause
 		}, "\t"))
 	}
 }

--- a/cmd/cireport/main.go
+++ b/cmd/cireport/main.go
@@ -46,7 +46,7 @@ func main() {
 		}
 
 		fmt.Println(strings.Join([]string{
-			j.ID,                               // ID
+			fmt.Sprintf(`=HYPERLINK("%s","%s")`, j.JobURL(), j.ID), // ID
 			startedAt.String(),                 // Started
 			finishedAt.Sub(startedAt).String(), // Duration
 			result,                             // Result

--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -87,3 +87,7 @@ func (j Job) Machines() (io.Reader, error) {
 func (j Job) Nodes() (io.Reader, error) {
 	return j.fetch(j.baseURL() + "/artifacts/" + j.Name + "/openstack_nodes.log")
 }
+
+func (j Job) JobURL() string {
+	return "https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-ocp-installer-" + j.Name + "-" + j.Target + "/" + j.ID
+}

--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -76,16 +76,28 @@ func (j Job) Result() (string, error) {
 	return finished.result, nil
 }
 
+func (j Job) BuildLogURL() string {
+	return j.baseURL() + "/build-log.txt"
+}
+
 func (j Job) BuildLog() (io.Reader, error) {
-	return j.fetch(j.baseURL() + "/build-log.txt")
+	return j.fetch(j.BuildLogURL())
+}
+
+func (j Job) MachinesURL() string {
+	return j.baseURL() + "/artifacts/" + j.Name + "/machines.json"
 }
 
 func (j Job) Machines() (io.Reader, error) {
-	return j.fetch(j.baseURL() + "/artifacts/" + j.Name + "/machines.json")
+	return j.fetch(j.MachinesURL())
+}
+
+func (j Job) NodesURL() string {
+	return j.baseURL() + "/artifacts/" + j.Name + "/openstack_nodes.log"
 }
 
 func (j Job) Nodes() (io.Reader, error) {
-	return j.fetch(j.baseURL() + "/artifacts/" + j.Name + "/openstack_nodes.log")
+	return j.fetch(j.NodesURL())
 }
 
 func (j Job) JobURL() string {


### PR DESCRIPTION
This makes the job ID clickable (leading to its prow page) as well as links for the build-log, machines and openstack_nodes logs.

The output can be pasted directly into a spreadsheet, which will interpret the `=HYPERLINK` directives as clickable links.

Fixes #1 