### PR TITLE
Categorize deployment timeouts as normal failures

### DIFF
--- a/pkg/rca/rule.go
+++ b/pkg/rca/rule.go
@@ -18,7 +18,12 @@ func infraFailureIfMatchBuildLogs(expr string, cause Cause) Rule {
 		}
 
 		if re.MatchReader(bufio.NewReader(f)) {
-			infraFailures <- cause
+			switch cause {
+			case CauseClusterTimeout:
+				testFailures <- cause
+			default:
+				infraFailures <- cause
+			}
 		}
 		return nil
 	}

--- a/pkg/rca/rule.go
+++ b/pkg/rca/rule.go
@@ -3,6 +3,7 @@ package rca
 import (
 	"bufio"
 	"encoding/xml"
+	"io"
 	"regexp"
 
 	"github.com/pierreprinetti/go-junit"
@@ -64,7 +65,9 @@ func infraFailureIfMatchNodes(expr string, cause Cause) Rule {
 func failedTests(j job, testFailures chan<- Cause, infraFailures chan<- Cause) error {
 	f, err := j.JUnit()
 	if err != nil {
-		testFailures <- Cause("Error parsing the JUnit file: " + err.Error())
+		if err != io.EOF {
+			testFailures <- Cause("Error parsing the JUnit file: " + err.Error())
+		}
 		return nil
 	}
 


### PR DESCRIPTION
Timeouts waiting for cluster to initialize can't be classified as Infra
Failures and may indicate a problem in the code. These failures should
be investigated individually.

Closes #10