### PR TITLE
Allow to specify job range and list

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The rules are coded in `pkg/rca/rule.go`. When new rules are coded, and add them
 
 ```shell
 go build ./cmd/cireport
-./cireport -job e2e-openstack-serial -target 4.2 -from 345 -to 346
+./cireport -job e2e-openstack-serial -target 4.2 -id 346-345
 ```
 
 ```HTML
@@ -23,5 +23,5 @@ go build ./cmd/cireport
 This command gets entries ready for pasting into the spreadsheet, given `$CLIPBOARD-COPY` your favourite clipboard "copy" command:
 
 ```shell
-./cireport -job e2e-openstack-serial -target 4.2 -from 345 -to 346 | tee /dev/stderr | tac | "$CLIPBOARD-COPY"
+./cireport -job e2e-openstack-serial -target 4.2 -id 346-345 | tee /dev/stderr | "$CLIPBOARD-COPY"
 ```

--- a/cmd/cireport/main.go
+++ b/cmd/cireport/main.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/pierreprinetti/go-sequence"
 	"github.com/shiftstack/gazelle/pkg/job"
 	"github.com/shiftstack/gazelle/pkg/rca"
 )
@@ -14,12 +15,16 @@ import (
 var (
 	jobName string
 	target  string
-	from    int
-	to      int
+	jobIDs  string
 )
 
 func main() {
-	for i := from; i <= to; i++ {
+	ids, err := sequence.Int(jobIDs)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, i := range ids {
 		j := job.Job{
 			Name:   jobName,
 			Target: target,
@@ -104,8 +109,7 @@ func reduceFailures(failures <-chan rca.Cause) []string {
 func init() {
 	flag.StringVar(&jobName, "job", "", "Name of the test job")
 	flag.StringVar(&target, "target", "", "Target OpenShift version")
-	flag.IntVar(&from, "from", 1, "First job to fetch")
-	flag.IntVar(&to, "to", 1, "Last job to fetch")
+	flag.StringVar(&jobIDs, "id", "", "Job IDs")
 
 	flag.Parse()
 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/shiftstack/gazelle
 
 go 1.13
 
-require github.com/pierreprinetti/go-junit v0.0.0-20191108173055-e4de85df7371
+require (
+	github.com/pierreprinetti/go-junit v0.0.0-20191108173055-e4de85df7371
+	github.com/pierreprinetti/go-sequence v0.0.0-20200108083045-8b6bac83cb4f
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/pierreprinetti/go-junit v0.0.0-20191108173055-e4de85df7371 h1:t86ZIpYAE8GvvhsZLrjY6LAwi6K0tIGX/vf0AoUeY54=
 github.com/pierreprinetti/go-junit v0.0.0-20191108173055-e4de85df7371/go.mod h1:RXr9e/v6e6B7fH3thOugnnsIQx5CXue8QnOZbpiu7x8=
+github.com/pierreprinetti/go-sequence v0.0.0-20200108083045-8b6bac83cb4f h1:xS9ZgTgp1KEpHBwR0s9eZFWCd7y7dKAJsIVxuKN8nZ0=
+github.com/pierreprinetti/go-sequence v0.0.0-20200108083045-8b6bac83cb4f/go.mod h1:Ns7OsLh2u5GA5q5gFZ17hl1EmnNticMRek5vWQqSRKk=


### PR DESCRIPTION
API change: instead of `-from` and `-to`, you now pass the job IDs with
`-id`.

Examples:

    ./cireport -job e2e-openstack-serial -target 4.2 -id 346
    ./cireport -job e2e-openstack-serial -target 4.2 -id 346-342
    ./cireport -job e2e-openstack-serial -target 4.2 -id 1,2,5,7-9

Implements https://github.com/shiftstack/gazelle/issues/8