### PR TITLE
Refactor failure channels

### DIFF
--- a/pkg/rca/causes.go
+++ b/pkg/rca/causes.go
@@ -8,3 +8,17 @@ const (
 	CauseMachineTimeout Cause = "Provisioned VM in BUILD state after 30m0s"
 	CauseClusterTimeout Cause = "Timeout waiting for cluster to initialize"
 )
+
+func (c Cause) IsInfra() bool {
+	switch c {
+	case CauseErroredVM, CauseErroredVolume, CauseMachineTimeout:
+		return true
+	default:
+		return false
+	}
+}
+
+// String implements fmt.Stringer
+func (c Cause) String() string {
+	return string(c)
+}


### PR DESCRIPTION
Failures are now passed in a single channel, and introspection is used
to determine if it is infra.

This is the meat of it:

```Go
func (c Cause) IsInfra() bool {
	switch c {
	case CauseErroredVM, CauseErroredVolume, CauseMachineTimeout:
		return true
	default:
		return false
	}
}
```