### PR TITLE
Remove `target` option, accept full job name

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The rules are coded in `pkg/rca/rule.go`. When new rules are coded, and add them
 
 ```shell
 go build ./cmd/cireport
-./cireport -job e2e-openstack-serial -target 4.2 -id 346-345
+./cireport -job release-openshift-origin-installer-e2e-openstack-serial-4.2 -id 346-345
 ```
 
 ```HTML
@@ -23,5 +23,5 @@ go build ./cmd/cireport
 This command gets entries ready for pasting into the spreadsheet, given `$CLIPBOARD-COPY` your favourite clipboard "copy" command:
 
 ```shell
-./cireport -job e2e-openstack-serial -target 4.2 -id 346-345 | tee /dev/stderr | "$CLIPBOARD-COPY"
+./cireport -job release-openshift-ocp-installer-e2e-openstack-serial-4.2 -id 346-345 | tee /dev/stderr | "$CLIPBOARD-COPY"
 ```

--- a/cmd/cireport/main.go
+++ b/cmd/cireport/main.go
@@ -13,8 +13,7 @@ import (
 )
 
 var (
-	jobName string
-	target  string
+	fullJobName string
 	jobIDs  string
 )
 
@@ -26,8 +25,7 @@ func main() {
 
 	for _, i := range ids {
 		j := job.Job{
-			Name:   jobName,
-			Target: target,
+			FullName: fullJobName,
 			ID:     strconv.Itoa(i),
 		}
 
@@ -78,6 +76,17 @@ func main() {
 			result = "INFRA FAILURE"
 		}
 
+		var machinesURL string
+		machinesURL, err = j.MachinesURL()
+		if err != nil {
+			panic(err)
+		}
+		var nodesURL string
+		nodesURL, err = j.NodesURL()
+		if err != nil {
+			panic(err)
+		}
+
 		var s strings.Builder
 		{
 			s.WriteString(`<meta http-equiv="content-type" content="text/html; charset=utf-8"><meta name="generator" content="cireport"/><table xmlns="http://www.w3.org/1999/xhtml"><tbody><tr><td>`)
@@ -88,8 +97,8 @@ func main() {
 				result,
 				"",
 				`<a href="` + j.BuildLogURL() + `">` + j.BuildLogURL() + `</a>`,
-				`<a href="` + j.MachinesURL() + `">` + j.MachinesURL() + `</a>`,
-				`<a href="` + j.NodesURL() + `">` + j.NodesURL() + `</a>`,
+				`<a href="` + machinesURL + `">` + machinesURL + `</a>`,
+				`<a href="` + nodesURL + `">` + nodesURL + `</a>`,
 				"cireport",
 				strings.Join(rootCause, "<br />"),
 			}, "</td><td>"))
@@ -100,8 +109,7 @@ func main() {
 }
 
 func init() {
-	flag.StringVar(&jobName, "job", "", "Name of the test job")
-	flag.StringVar(&target, "target", "", "Target OpenShift version")
+	flag.StringVar(&fullJobName, "job", "", "Full name of the test job (e.g. release-openshift-ocp-installer-e2e-openstack-serial-4.4)")
 	flag.StringVar(&jobIDs, "id", "", "Job IDs")
 
 	flag.Parse()

--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -12,6 +12,9 @@ import (
 	"github.com/shiftstack/gazelle/pkg/cache"
 )
 
+var jobTargetRexexp = regexp.MustCompile(`release-openshift-(ocp|origin)-installer-(.*)-\d.\d`);
+
+
 type Job struct {
 	FullName string
 	Target string
@@ -34,8 +37,7 @@ func (j *Job) fetch(file string) (io.Reader, error) {
 }
 
 func (j *Job) Name() (string, error) {
-	re := regexp.MustCompile(`release-openshift-(ocp|origin)-installer-(.*)-\d.\d`);
-	matches := re.FindStringSubmatch(j.FullName);
+	matches := jobTargetRexexp.FindStringSubmatch(j.FullName);
 
 	if (len(matches) >= 3) {
 		return matches[2], nil

--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -5,13 +5,15 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"regexp"
 	"time"
+	"fmt"
 
 	"github.com/shiftstack/gazelle/pkg/cache"
 )
 
 type Job struct {
-	Name   string
+	FullName string
 	Target string
 	ID     string
 
@@ -21,7 +23,7 @@ type Job struct {
 }
 
 func (j Job) baseURL() string {
-	return "https://storage.googleapis.com/origin-ci-test/logs/release-openshift-ocp-installer-" + j.Name + "-" + j.Target + "/" + j.ID
+	return "https://storage.googleapis.com/origin-ci-test/logs/" + j.FullName + "/" + j.ID
 }
 
 func (j *Job) fetch(file string) (io.Reader, error) {
@@ -29,6 +31,17 @@ func (j *Job) fetch(file string) (io.Reader, error) {
 		j.cache = new(cache.Cache)
 	}
 	return j.cache.Get(file)
+}
+
+func (j *Job) Name() (string, error) {
+	re := regexp.MustCompile(`release-openshift-(ocp|origin)-installer-(.*)-\d.\d`);
+	matches := re.FindStringSubmatch(j.FullName);
+
+	if (len(matches) >= 3) {
+		return matches[2], nil
+	} else {
+		return "", fmt.Errorf("Could not determine job name from %s", j.FullName)
+	}
 }
 
 func (j Job) StartTime() (time.Time, error) {
@@ -81,24 +94,40 @@ func (j Job) BuildLog() (io.Reader, error) {
 	return j.fetch(j.BuildLogURL())
 }
 
-func (j Job) MachinesURL() string {
-	return j.baseURL() + "/artifacts/" + j.Name + "/machines.json"
+func (j Job) MachinesURL() (string, error) {
+	name, err := j.Name()
+	if err != nil {
+		return "", err
+	}
+	return j.baseURL() + "/artifacts/" + name + "/machines.json", nil
 }
 
 func (j Job) Machines() (io.Reader, error) {
-	return j.fetch(j.MachinesURL())
+	url, err := j.MachinesURL()
+	if err != nil {
+		return nil, err
+	}
+	return j.fetch(url)
 }
 
-func (j Job) NodesURL() string {
-	return j.baseURL() + "/artifacts/" + j.Name + "/openstack_nodes.log"
+func (j Job) NodesURL() (string, error) {
+	name, err := j.Name()
+	if err != nil {
+		return "", err
+	}
+	return j.baseURL() + "/artifacts/" + name + "/openstack_nodes.log", nil
 }
 
 func (j Job) Nodes() (io.Reader, error) {
-	return j.fetch(j.NodesURL())
+	url, err := j.NodesURL()
+	if err != nil {
+		return nil, err
+	}
+	return j.fetch(url)
 }
 
 func (j Job) JobURL() string {
-	return "https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-ocp-installer-" + j.Name + "-" + j.Target + "/" + j.ID
+	return "https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/" + j.FullName + "/" + j.ID
 }
 
 func (j Job) JUnitURL() (string, error) {
@@ -118,11 +147,16 @@ func (j Job) JUnitURL() (string, error) {
 	scanner := bufio.NewScanner(buildLog)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 
+	var jobName string;
+	jobName, err = j.Name()
+	if err != nil {
+		return "", err
+	}
 	for scanner.Scan() {
 		line := scanner.Text()
 		if len(line) >= targetLength && line[:len(target)] == target {
 			filename := line[len(target):]
-			return j.baseURL() + "/artifacts/" + j.Name + "/junit/" + filename, scanner.Err()
+			return j.baseURL() + "/artifacts/" + jobName + "/junit/" + filename, scanner.Err()
 		}
 	}
 


### PR DESCRIPTION
The `-job` commandline option now accepts the full job name. Instead
of: `e2e-openstack-serial` it takes:
release-openshift-ocp-installer-e2e-openstack-serial-4.4.

The `-target` option is no longer necessary so it is removed.

This lets gazelle to handle non-ocp jobs as well, such as
`release-openshift-origin-installer-e2e-openstack-serial-4.2`.

[breaking-change]