### PR TITLE
Add new RCA for release image failure

### DIFF
--- a/pkg/rca/causes.go
+++ b/pkg/rca/causes.go
@@ -7,11 +7,12 @@ const (
 	CauseErroredVolume  Cause = "Provisioned Volume in ERROR state"
 	CauseMachineTimeout Cause = "Provisioned VM in BUILD state after 30m0s"
 	CauseClusterTimeout Cause = "Timeout waiting for cluster to initialize"
+	CauseReleaseImage   Cause = "Unable to import release image"
 )
 
 func (c Cause) IsInfra() bool {
 	switch c {
-	case CauseErroredVM, CauseErroredVolume, CauseMachineTimeout:
+	case CauseErroredVM, CauseErroredVolume, CauseMachineTimeout, CauseReleaseImage:
 		return true
 	default:
 		return false

--- a/pkg/rca/rca.go
+++ b/pkg/rca/rca.go
@@ -22,6 +22,11 @@ var (
 			CauseClusterTimeout,
 		),
 
+		infraFailureIfMatchBuildLogs(
+			"failed: unable to import latest release image",
+			CauseReleaseImage,
+		),
+
 		infraFailureIfMatchMachines(
 			`"machine.openshift.io/instance-state": "ERROR"`,
 			CauseErroredVM,


### PR DESCRIPTION
Example job: https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-4.4/376