### PR TITLE
Added additional RCA for cluster deployment timeout

### DIFF
--- a/pkg/rca/rca.go
+++ b/pkg/rca/rca.go
@@ -28,6 +28,11 @@ var (
 		),
 
 		infraFailureIfMatchBuildLogs(
+			"failed to initialize the cluster: Working towards",
+			CauseClusterTimeout,
+		),
+
+		infraFailureIfMatchBuildLogs(
 			"failed: unable to import latest release image",
 			CauseReleaseImage,
 		),

--- a/pkg/rca/rca.go
+++ b/pkg/rca/rca.go
@@ -23,6 +23,11 @@ var (
 		),
 
 		infraFailureIfMatchBuildLogs(
+			"failed to initialize the cluster: Cluster operator [\\w-]+ is still updating",
+			CauseClusterTimeout,
+		),
+
+		infraFailureIfMatchBuildLogs(
 			"failed: unable to import latest release image",
 			CauseReleaseImage,
 		),

--- a/pkg/rca/rca.go
+++ b/pkg/rca/rca.go
@@ -33,6 +33,11 @@ var (
 		),
 
 		infraFailureIfMatchBuildLogs(
+			"failed to initialize the cluster: Multiple errors are preventing progress",
+			CauseClusterTimeout,
+		),
+
+		infraFailureIfMatchBuildLogs(
 			"failed: unable to import latest release image",
 			CauseReleaseImage,
 		),


### PR DESCRIPTION
Example job: https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-4.4/362