### PR TITLE
Add RCA for VM timeout

### DIFF
--- a/pkg/rca/rca.go
+++ b/pkg/rca/rca.go
@@ -13,6 +13,11 @@ var (
 		),
 
 		infraFailureIfMatchBuildLogs(
+			"to become ready: timeout while waiting for state to become 'ACTIVE'",
+			CauseErroredVM,
+		),
+
+		infraFailureIfMatchBuildLogs(
 			"The volume is in error status. Please check with your cloud admin",
 			CauseErroredVolume,
 		),


### PR DESCRIPTION
Categorized is as VM in error state, INFRA FAILURE.

Example job: https://storage.googleapis.com/origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-4.3/783/build-log.txt