### PR TITLE
Limit to 10 failed tests

### DIFF
--- a/pkg/rca/rule.go
+++ b/pkg/rca/rule.go
@@ -71,6 +71,11 @@ func failedTests(j job, failures chan<- Cause) error {
 		return err
 	}
 
+	if len(testSuite.TestCases) > 10 {
+		failures <- Cause("More than 10 failed tests")
+		return nil
+	}
+
 	for _, tc := range testSuite.TestCases {
 		if tc.Failure != nil {
 			failures <- Cause(tc.Name)


### PR DESCRIPTION
More than 10 failed tests means the problem might not be the tests.

Fixes an issue where too many failed tests exceeded the maximum Spreadsheets cell size.