### PR TITLE
Fix comment typo

### DIFF
--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -142,7 +142,7 @@ func (j Job) JUnitURL() (string, error) {
 		return "", err
 	}
 
-	// The default scanner buffer (60*1024 bytes) is too short for some
+	// The default scanner buffer (64*1024 bytes) is too short for some
 	// build logs. This sets the initial buffer capacity to the package
 	// default, but a higher maximum value.
 	scanner := bufio.NewScanner(buildLog)


### PR DESCRIPTION
As stated in the Go stdlib documentation, the maximum default size used
to buffer a torken is 64*1024 bytes.

ref: https://golang.org/pkg/bufio/#pkg-constants