### PR TITLE
DON'T PANIC

### DIFF
--- a/cmd/cireport/main.go
+++ b/cmd/cireport/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -34,7 +35,8 @@ func main() {
 
 		startedAt, err := j.StartTime()
 		if err != nil {
-			panic(err)
+			fmt.Fprintf(os.Stderr, "Error fetching job %d: %s\n", i, err)
+			continue
 		}
 
 		finishedAt, err := j.FinishTime()


### PR DESCRIPTION
When fetching the job, instead of aborting the whole thing on a
failure (such as 404), print a friendly message to STDERR, ignore the
job and keep going.

Some jobs get skipped completely[1] which resulted in a crash. By
continuing, we are able to collect all the other jobs while still
letting the user know something's wrong.

By printing it to the standard error, this won't pollute the XML
that's optionally passed to a clipboard command or some other
reporting tool.

[1]: https://storage.googleapis.com/origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-serial-4.3/827/started.json