### PR TITLE
Add RCA for missing image in release image

### DIFF
--- a/pkg/rca/rca.go
+++ b/pkg/rca/rca.go
@@ -47,6 +47,11 @@ var (
 			CauseReleaseImage,
 		),
 
+		ifMatchBuildLogs(
+			"failed: unable to find the '[\\w-]+' image in the provided release image",
+			CauseReleaseImage,
+		),
+
 		ifMatchMachines(
 			`"machine.openshift.io/instance-state": "ERROR"`,
 			CauseErroredVM,


### PR DESCRIPTION
Example https://storage.googleapis.com/origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-serial-4.4/580/build-log.txt