### PR TITLE
Add RCA for lease failure

### DIFF
--- a/pkg/rca/causes.go
+++ b/pkg/rca/causes.go
@@ -11,6 +11,7 @@ type Cause interface {
 const (
 	CauseErroredVM      CauseInfra = "Provisioned VM in ERROR state"
 	CauseErroredVolume  CauseInfra = "Provisioned Volume in ERROR state"
+	CauseLeaseFailure   CauseInfra = "Failed to acquire lease"
 	CauseMachineTimeout CauseInfra = "Provisioned VM in BUILD state after 30m0s"
 	CauseReleaseImage   CauseInfra = "Unable to import release image"
 	CauseRoute53        CauseInfra = "Route53 failure"

--- a/pkg/rca/rca.go
+++ b/pkg/rca/rca.go
@@ -77,6 +77,11 @@ var (
 			CauseRoute53,
 		),
 
+		ifMatchBuildLogs(
+			`failed to acquire lease`,
+			CauseLeaseFailure,
+		),
+
 		failedTests,
 	}
 )


### PR DESCRIPTION
Treat failure to acquire lease as infra failure.

Example job: https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-4.4/681