### PR TITLE
Added RCA for bootstrap timeout

### DIFF
--- a/pkg/rca/causes.go
+++ b/pkg/rca/causes.go
@@ -16,7 +16,8 @@ const (
 	CauseReleaseImage   CauseInfra = "Unable to import release image"
 	CauseRoute53        CauseInfra = "Route53 failure"
 
-	CauseClusterTimeout CauseGeneric = "Timeout waiting for cluster to initialize"
+	CauseBootstrapTimeout CauseGeneric = "Timeout waiting for bootstrap to initialize"
+	CauseClusterTimeout   CauseGeneric = "Timeout waiting for cluster to initialize"
 )
 
 type CauseGeneric string

--- a/pkg/rca/rca.go
+++ b/pkg/rca/rca.go
@@ -43,6 +43,11 @@ var (
 		),
 
 		ifMatchBuildLogs(
+			"failed to wait for bootstrapping to complete",
+			CauseBootstrapTimeout,
+		),
+
+		ifMatchBuildLogs(
 			"failed: unable to import latest release image",
 			CauseReleaseImage,
 		),


### PR DESCRIPTION
We got a few instances of these lately.
Example job: https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-4.4/668