### PR TITLE
 Add arbitrary infra checks

### DIFF
--- a/pkg/rca/rca.go
+++ b/pkg/rca/rca.go
@@ -89,6 +89,7 @@ var (
 
 		findBuildLogsInfra(
 			`error: could not run steps: step \[release-inputs\] failed.*`,
+			`An unexpected error prevented the server from fulfilling your request. \(HTTP \d{3}\)`,
 		),
 
 		failedTests,

--- a/pkg/rca/rca.go
+++ b/pkg/rca/rca.go
@@ -87,6 +87,10 @@ var (
 			CauseLeaseFailure,
 		),
 
+		findBuildLogsInfra(
+			`error: could not run steps: step \[release-inputs\] failed.*`,
+		),
+
 		failedTests,
 	}
 )

--- a/pkg/rca/rca.go
+++ b/pkg/rca/rca.go
@@ -90,6 +90,7 @@ var (
 		findBuildLogsInfra(
 			`error: could not run steps: step \[release-inputs\] failed.*`,
 			`An unexpected error prevented the server from fulfilling your request. \(HTTP \d{3}\)`,
+			`error: could not run steps: step \[release:latest\] failed: the following tags from the release could not be imported to stable after five minutes.*`,
 		),
 
 		failedTests,

--- a/pkg/rca/rule.go
+++ b/pkg/rca/rule.go
@@ -2,9 +2,11 @@ package rca
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/xml"
 	"io"
 	"regexp"
+	"strings"
 
 	"github.com/pierreprinetti/go-junit"
 )
@@ -53,6 +55,29 @@ func ifMatchNodes(expr string, cause Cause) Rule {
 		if re.MatchReader(bufio.NewReader(f)) {
 			failures <- cause
 		}
+		return nil
+	}
+}
+
+// findBuildLogsInfra creates an infra failure for the first match among the
+// given expressions
+func findBuildLogsInfra(expressions ...string) Rule {
+	re := regexp.MustCompile(strings.Join(expressions, "|"))
+
+	return func(j job, failures chan<- Cause) error {
+		f, err := j.BuildLog()
+		if err != nil {
+			failures <- CauseGeneric("Failed to get build log: " + err.Error())
+			return nil
+		}
+
+		var buf bytes.Buffer
+		r := io.TeeReader(f, &buf)
+
+		if loc := re.FindReaderIndex(bufio.NewReader(r)); loc != nil {
+			failures <- CauseInfra(buf.Bytes()[loc[0]:loc[1]])
+		}
+
 		return nil
 	}
 }


### PR DESCRIPTION
Add arbitrary infra checks

An arbitrary match can now trigger an infra failure. The matching string
will be used as Cause.

Fixes https://github.com/shiftstack/gazelle/issues/35
