### PR TITLE
Do not make missing job fatal

### DIFF
--- a/pkg/gsheets/sheet.go
+++ b/pkg/gsheets/sheet.go
@@ -131,7 +131,10 @@ func (s *Sheet) AddRow(j job.Job, user string) {
 
 	// Let's try render the job early so that we do not create a empty row
 	// if the job does not exist
-	rendered_job := jobToHtml(j, user)
+	rendered_job, err := jobToHtml(j, user)
+	if err != nil {
+		return
+	}
 
 	if !exists {
 		// Create a new row to save the report
@@ -183,16 +186,17 @@ func (s *Sheet) AddRow(j job.Job, user string) {
 		},
 	}
 
-	_, err := s.Client.service.Spreadsheets.BatchUpdate(s.Client.spreadsheetId, request).Context(context.Background()).Do()
+	_, err = s.Client.service.Spreadsheets.BatchUpdate(s.Client.spreadsheetId, request).Context(context.Background()).Do()
 	if err != nil {
 		log.Fatal(err)
 	}
 }
 
-func jobToHtml(j job.Job, user string) string {
+func jobToHtml(j job.Job, user string) (string, error) {
 	startTime, err := j.StartTime()
 	if err != nil {
-		log.Fatalf("Could not fetch information about job %v: %v", j.ID, err)
+		log.Printf("Could not fetch information about job %v: %v", j.ID, err)
+		return "", err
 	}
 	var s strings.Builder
 	{
@@ -208,5 +212,5 @@ func jobToHtml(j job.Job, user string) string {
 		}, "</td><td>"))
 		s.WriteString(`</td></tr></tbody></table>`)
 	}
-	return s.String()
+	return s.String(), nil
 }

--- a/pkg/gsheets/sheet.go
+++ b/pkg/gsheets/sheet.go
@@ -133,6 +133,7 @@ func (s *Sheet) AddRow(j job.Job, user string) {
 	// if the job does not exist
 	rendered_job, err := jobToHtml(j, user)
 	if err != nil {
+		log.Printf("Could not fetch information about job %v: %v", j.ID, err)
 		return
 	}
 
@@ -195,7 +196,6 @@ func (s *Sheet) AddRow(j job.Job, user string) {
 func jobToHtml(j job.Job, user string) (string, error) {
 	startTime, err := j.StartTime()
 	if err != nil {
-		log.Printf("Could not fetch information about job %v: %v", j.ID, err)
 		return "", err
 	}
 	var s strings.Builder


### PR DESCRIPTION
There could be cases where jobs do not exist.  For instance, job ID
818-832 are missing in prow for parallel ocp 4.4 job.

This commit makes a missing job a non fatal error, and gazelle now
simply skips them.

Superseds #29