### PR TITLE
Fix --id option

### DIFF
--- a/cmd/cireport/main.go
+++ b/cmd/cireport/main.go
@@ -47,8 +47,8 @@ func main() {
 			Client:  &client,
 		}
 
-		var realJobIDs string
-		if jobIDs == "" {
+		realJobIDs := jobIDs
+		if realJobIDs == "" {
 			lowerBound := sheet.GetLatestId() + 1
 			upperBound := prow.GetLatestId(jobName)
 			if lowerBound < upperBound {


### PR DESCRIPTION
Commit d6ad3d7 introduced a regression where passing the job IDs with
the `-id` flag would result in an empty list.

This commit fixes it by setting the realJobIDs variable correctly.