### PR TITLE
Add generic 'step [release/latest] failed'

### DIFF
--- a/pkg/rca/rca.go
+++ b/pkg/rca/rca.go
@@ -88,9 +88,8 @@ var (
 		),
 
 		findBuildLogsInfra(
-			`error: could not run steps: step \[release-inputs\] failed.*`,
+			`error: could not run steps: step \[.*\] failed.*`,
 			`An unexpected error prevented the server from fulfilling your request. \(HTTP \d{3}\)`,
-			`error: could not run steps: step \[release:latest\] failed: the following tags from the release could not be imported to stable after five minutes.*`,
 		),
 
 		findBuildLogsGeneric(


### PR DESCRIPTION
e.g. https://storage.googleapis.com/origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-serial-4.4/955/build-log.txt