### PR TITLE
Infra

### DIFF
--- a/pkg/rca/rca.go
+++ b/pkg/rca/rca.go
@@ -89,8 +89,11 @@ var (
 
 		findBuildLogsInfra(
 			`error: could not run steps: step \[.*\] failed.*`,
+			`error: could not resolve inputs: could not determine inputs for step \[.*\].*`,
 			`An unexpected error prevented the server from fulfilling your request. \(HTTP \d{3}\)`,
 			`Failed to open /logs/process-log.txt: open /logs/process-log.txt: no such file or directory`,
+			`Entrypoint received interrupt: terminated`,
+			`error: could not initialize namespace.*`,
 		),
 
 		findBuildLogsGeneric(

--- a/pkg/rca/rca.go
+++ b/pkg/rca/rca.go
@@ -98,6 +98,7 @@ var (
 
 		findBuildLogsGeneric(
 			`failed to fetch Terraform Variables: failed to generate asset .*`,
+			`INFO: Unexpected error listing nodes.*`,
 		),
 
 		failedTests,


### PR DESCRIPTION
Add some infra failures.

`Unexpected error listing nodes` is added as a regulard failure, and not infra, because it is just a hint for human investigation.