### PR TITLE
Add a cireport hint for a failure

### DIFF
--- a/pkg/rca/rca.go
+++ b/pkg/rca/rca.go
@@ -106,6 +106,7 @@ var (
 		findBuildLogsGeneric(
 			`failed to fetch Terraform Variables: failed to generate asset .*`,
 			`INFO: Unexpected error listing nodes.*`,
+			`level=info msg="Cluster operator insights Disabled is False with : "`,
 		),
 
 		failedTests,


### PR DESCRIPTION
"Cluster operator insights Disabled is False with :"

eg [release-openshift-ocp-installer-e2e-openstack-serial-4.4#1402](https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-serial-4.4/1402)