### PR TITLE
Fix Pending ignore

### DIFF
--- a/pkg/prow/prow.go
+++ b/pkg/prow/prow.go
@@ -101,13 +101,13 @@ func JobIDs(ctx context.Context, jobName string, from int64) <-chan int64 {
 				if id < from {
 					continue
 				}
-				if id == lastJobID {
+				if id >= lastJobID {
 					finished, err := jobIsFinished(ctx, bkt, jobName, id)
 					if err != nil {
 						panic(err)
 					}
 					if !finished {
-						continue
+						break
 					}
 				}
 				ids <- id


### PR DESCRIPTION
Before this patch, only the job whose ID matched latest-job.txt was
checked for Pending.

However, the latest-job.txt file sometimes references the latest
finished job, and sometimes the latest started job.

With this patch, all jobs with ID greater than or equal to latest-job
are checked.