### PR TITLE
Improve regex to match more job names

### DIFF
--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	jobTargetRegexp        = regexp.MustCompile(`^periodic-ci-openshift-release-master-ci-\d\.\d-(.*)$`)
+	jobTargetRegexp        = regexp.MustCompile(`^periodic-ci-openshift-release-master-\w+-\d+\.\d+-(.*)$`)
 	jobTargetRegexpUpgrade = regexp.MustCompile(`e2e-openstack-upgrade$`)
 )
 


### PR DESCRIPTION
This should now match jobs like:
- periodic-ci-openshift-release-master-ci-4.10-e2e-openstack-parallel
- periodic-ci-openshift-release-master-nightly-4.10-e2e-openstack-fips