### PR TITLE
Use context for building the gsheet client

### DIFF
--- a/cmd/cireport/main.go
+++ b/cmd/cireport/main.go
@@ -59,8 +59,8 @@ func toBufferedChannel(numbers ...int64) <-chan int64 {
 }
 
 func main() {
-	ctx := context.TODO()
-	client := gsheets.NewClient()
+	ctx := context.Background()
+	client := gsheets.NewClient(ctx)
 
 	var jobs []string
 	if requestedJobName == "" {


### PR DESCRIPTION
Also replace the deprecated `sheets.New` function with `sheets.NewService`.

On my way to trying to fix an unrelated wicked issue, I found this low hanging fruit that could relieve my pain a bit.