### PR TITLE
Update job name matching regexp

### DIFF
--- a/pkg/job/job.go
+++ b/pkg/job/job.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	jobTargetRegexp        = regexp.MustCompile(`^periodic-ci-openshift-release-master-\w+-\d+\.\d+-(.*)$`)
+	jobTargetRegexp        = regexp.MustCompile(`^periodic-ci-shiftstack-shiftstack-ci-main-\w+-\d+\.\d+-(.*)$`)
 	jobTargetRegexpUpgrade = regexp.MustCompile(`e2e-openstack-upgrade$`)
 )
 


### PR DESCRIPTION
The jobs were moved to shiftstack-ci and consequently their names
changed. We need to update the regex to get the job shortname, otherwise
it fills our spreadsheet with tons of `Failed to get OpenStack Nodes
information: Could not determine job name from blah blah blah` messages.